### PR TITLE
BUG bei Versichertennummern, die mit einem i beginnen (z.B. I000000009)

### DIFF
--- a/includes/validator.php
+++ b/includes/validator.php
@@ -59,7 +59,7 @@ class gesundheitsdatenbefreier_Validator {
 	
 	private static function modified_luhn($number) {		
 		$firstLetterValue = ord(strtoupper(substr($number, 0, 1))) - ord('A') + 1;
-		if($firstLetterValue < 9) {
+		if($firstLetterValue <= 9) {
 			$firstLetterValue = '0' . $firstLetterValue;
 		}
 		$number = $firstLetterValue . substr($number, 1);


### PR DESCRIPTION
Versichertennummern, die mit einem i beginnen gibt es auch.
I = 73; 73 - ord(A) = 9. Bei einer 9 muss auch eine 0 vorangestellt werden.